### PR TITLE
KAN-35 refactor: replaced icons with components in the registration form

### DIFF
--- a/src/features/password-recovery-form/ForgotPasswordForm.tsx
+++ b/src/features/password-recovery-form/ForgotPasswordForm.tsx
@@ -28,7 +28,7 @@ export const ForgotPasswordForm = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Card className="flex flex-col items-center max-w-[378px] p-[24px] gap-2">
+      <Card className="flex flex-col items-center max-w-[378px] p-[24px] mx-auto my-auto gap-2">
         <span className="pb-[20px] text-h1">{t.auth.forgotPassword}</span>
         <Controller
           control={control}

--- a/src/features/sign-in/SignInForm.tsx
+++ b/src/features/sign-in/SignInForm.tsx
@@ -30,7 +30,7 @@ export const SignInForm = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Card className="flex flex-col p-6 items-center">
+      <Card className="flex flex-col max-w-[360px] sl:max-w-[378px] p-6 mx-auto my-auto items-center">
         <div>
           <span className="text-h1">{t.auth.signIn}</span>
         </div>

--- a/src/features/sign-up-form/SignUpForm.tsx
+++ b/src/features/sign-up-form/SignUpForm.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Controller } from 'react-hook-form'
 
 import { SignUpFormType, useSignUpForm } from '@/features/sign-up-form/useSignUpForm'
@@ -6,7 +7,8 @@ import Button from '@/shared/ui/Button/Button'
 import { Card } from '@/shared/ui/Card/Card'
 import { Checkbox } from '@/shared/ui/Checkbox/Checkbox'
 import { Input } from '@/shared/ui/Input/Input'
-import Image from 'next/image'
+import { GithubAuth } from '@/shared/ui/githubAuth'
+import { GoogleButton } from '@/shared/ui/googleAuth'
 import Link from 'next/link'
 
 import { useTranslation } from '../../../hooks/useTranslation'
@@ -31,12 +33,8 @@ export const SignUpForm = () => {
         <h1 className="text-light-100 text-h1 text-center mb-[13px]">{t.auth.signUp}</h1>
 
         <div className="flex justify-evenly mb-[24px]">
-          <Link href={'https://www.google.com/?client=safari'} target="_blank">
-            <Image alt="google-icon" height={36} src="/google.svg" width={36}></Image>
-          </Link>
-          <Link href={'https://github.com'} target="_blank">
-            <Image alt="github-icon" height={36} src="/git.svg" width={36}></Image>
-          </Link>
+          <GoogleButton />
+          <GithubAuth />
         </div>
 
         <div className="flex flex-col gap-[20px] mb-[20px]">


### PR DESCRIPTION
 replaced icons with components in the registration form
 
<img width="361" alt="image" src="https://github.com/instaitincubator/instagram/assets/121195344/faed438e-ffa2-4433-b62d-3eed1584e7e9">

changed the css in the login and password recovery form
<img width="738" alt="image" src="https://github.com/instaitincubator/instagram/assets/121195344/95541848-005e-460a-a6fb-41ef5a75c88c">
